### PR TITLE
add KEC Computer Club

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ List of Tech Communities in Nepal on Github.
 - [HCOE Developers Circle](https://github.com/hcoedevcircle)
 - [Kathmandu Javascript User Group](https://github.com/developers-nepal/ktmjs)
 - [Kathmandu Living Labs](https://github.com/KathmanduLivingLabs) 
+- [KEC Computer Club](https://github.com/computerclubkec)
 - [KEC Developers Circle](https://github.com/kec-developers-circle)
 - [KEC IT Club](https://github.com/kec-it-club)
 - [LOCUS IOE, Pulchowk](https://github.com/locus-ioe)


### PR DESCRIPTION
This PR will add KEC Computer Club in the list in the sorted order.

KEC Computer Club of Kantipur Engineering College, founded in 2013, empowers students to explore ideas and develop skills in the field of computers. Run by tech enthusiasts, the club exposes members to the latest advancements, offering guidance, workshops, and events that foster innovation and confidence. It’s a platform for engineering students to implement their ideas and grow in the rapidly evolving tech world.